### PR TITLE
Feat : 로그인&로그아웃을 구현한다

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,7 +6,7 @@ const Header = () => `
   <ul class="flex justify-around">
     <li><a href="/" class="text-blue-600">홈</a></li>
     <li><a href="/profile" class="text-gray-600">프로필</a></li>
-    <li><a href="#" class="text-gray-600">로그아웃</a></li>
+    <li><a href="#" id="logout" class="text-gray-600">로그아웃</a></li>
   </ul>
   </nav>
 `;

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import Footer from "./components/Footer";
 import ErrorPage from "./pages/Error";
 import routes from "./routes";
 import checkLogin from "./utils/checkLogin";
+import login from "./utils/login";
 
 /**
  * @description path에 따라 렌더해주는 함수. routes내 허용되는 값이 아닌 경우 에러페이지로 라우팅
@@ -27,6 +28,10 @@ const render = (path) => {
       </div>
     </div>
   `;
+
+  if (path === "/login") {
+    login();
+  }
 };
 
 const navigateTo = (path) => {

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import login from "./utils/login";
 /**
  * @description path에 따라 렌더해주는 함수. routes내 허용되는 값이 아닌 경우 에러페이지로 라우팅
  */
-const render = (path) => {
+export const render = (path) => {
   const root = document.getElementById("root");
   const allowConditions = ["/", "/profile"];
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import ErrorPage from "./pages/Error";
 import routes from "./routes";
 import checkLogin from "./utils/checkLogin";
 import login from "./utils/login";
+import logout from "./utils/logout";
 
 /**
  * @description path에 따라 렌더해주는 함수. routes내 허용되는 값이 아닌 경우 에러페이지로 라우팅
@@ -32,6 +33,13 @@ export const render = (path) => {
   if (path === "/login") {
     login();
   }
+
+  const logoutButton = document.getElementById("logout");
+  logoutButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    logout();
+  });
+  console.log("lg : ", logoutButton);
 };
 
 const navigateTo = (path) => {

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -4,10 +4,10 @@ const LoginPage = () => `
       <h1 class="text-2xl font-bold text-center text-blue-600 mb-8">항해플러스</h1>
       <form>
         <div class="mb-4">
-          <input type="text" placeholder="이메일 또는 전화번호" class="w-full p-2 border rounded">
+          <input type="text" id="username" placeholder="이메일 또는 전화번호" class="w-full p-2 border rounded">
         </div>
         <div class="mb-6">
-          <input type="password" placeholder="비밀번호" class="w-full p-2 border rounded">
+          <input type="password" id="password" placeholder="비밀번호" class="w-full p-2 border rounded">
         </div>
         <button type="submit" class="w-full bg-blue-600 text-white p-2 rounded font-bold">로그인</button>
       </form>

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -2,7 +2,7 @@ const LoginPage = () => `
   <main class="bg-gray-100 flex items-center justify-center min-h-screen">
     <div class="bg-white p-8 rounded-lg shadow-md w-full max-w-md">
       <h1 class="text-2xl font-bold text-center text-blue-600 mb-8">항해플러스</h1>
-      <form>
+      <form id="login-form">
         <div class="mb-4">
           <input type="text" id="username" placeholder="이메일 또는 전화번호" class="w-full p-2 border rounded">
         </div>

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,4 +1,7 @@
-const ProfilePage = () => `
+const ProfilePage = () => {
+  const user = JSON.parse(window.localStorage.getItem("user"));
+  if (!user) return;
+  return `
         <main class="p-4">
           <div class="bg-white p-8 rounded-lg shadow-md">
             <h2 class="text-2xl font-bold text-center text-blue-600 mb-8">
@@ -15,7 +18,7 @@ const ProfilePage = () => `
                   type="text"
                   id="username"
                   name="username"
-                  value="홍길동"
+                  value="${user.username}"
                   class="w-full p-2 border rounded"
                 />
               </div>
@@ -29,7 +32,7 @@ const ProfilePage = () => `
                   type="email"
                   id="email"
                   name="email"
-                  value="hong@example.com"
+                  value="${user.email || ""}"
                   class="w-full p-2 border rounded"
                 />
               </div>
@@ -45,7 +48,7 @@ const ProfilePage = () => `
                   rows="4"
                   class="w-full p-2 border rounded"
                 >
-안녕하세요, 항해플러스에서 열심히 공부하고 있는 홍길동입니다.</textarea
+                ${user.bio || ""}</textarea
                 >
               </div>
               <button
@@ -58,5 +61,6 @@ const ProfilePage = () => `
           </div>
         </main>
 `;
+};
 
 export default ProfilePage;

--- a/src/utils/checkLogin.js
+++ b/src/utils/checkLogin.js
@@ -1,7 +1,7 @@
 const checkLogin = () => {
-  const loginInfo = window.localStorage.getItem("loginInfo");
+  const user = window.localStorage.getItem("user");
 
-  if (!loginInfo) {
+  if (!user) {
     return false;
   }
   return true;

--- a/src/utils/login.js
+++ b/src/utils/login.js
@@ -1,0 +1,16 @@
+const login = () => {
+  const loginForm = document.querySelector("form");
+  console.log("lf : ", loginForm);
+  if (loginForm) {
+    loginForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+
+      const username = document.getElementById("username").value;
+      const password = document.getElementById("password").value;
+      console.log("Username:", username);
+      console.log("Password:", password);
+    });
+  }
+};
+
+export default login;

--- a/src/utils/login.js
+++ b/src/utils/login.js
@@ -7,14 +7,13 @@ const login = () => {
       event.preventDefault();
 
       const username = document.getElementById("username").value;
-      const password = document.getElementById("password").value;
+      document.getElementById("password").value;
 
       if (!username) {
         return;
       }
       const information = {
         username: username,
-        password: password,
         email: "",
         bio: "",
       };

--- a/src/utils/login.js
+++ b/src/utils/login.js
@@ -1,14 +1,26 @@
+import { render } from "../main";
+
 const login = () => {
   const loginForm = document.querySelector("form");
-  console.log("lf : ", loginForm);
   if (loginForm) {
     loginForm.addEventListener("submit", (event) => {
       event.preventDefault();
 
       const username = document.getElementById("username").value;
       const password = document.getElementById("password").value;
-      console.log("Username:", username);
-      console.log("Password:", password);
+
+      if (!username) {
+        return;
+      }
+      const information = {
+        username: username,
+        password: password,
+        email: "",
+        bio: "",
+      };
+      window.localStorage.setItem("user", JSON.stringify(information));
+      window.history.pushState({}, "", "/");
+      render("/");
     });
   }
 };

--- a/src/utils/logout.js
+++ b/src/utils/logout.js
@@ -1,0 +1,5 @@
+const logout = () => {
+  window.localStorage.removeItem("user");
+};
+
+export default logout;


### PR DESCRIPTION

## 로그인&로그아웃 구현 

<img width="1470" alt="스크린샷 2024-12-16 오후 10 15 58" src="https://github.com/user-attachments/assets/33be85e6-7d62-48d9-b0a4-44431638fef2" />

로그인 폼에서 사용자 이름을 입력하고 제출한 경우 로그인이 되도록 구현했습니다. 

가능한 페이지 컴포넌트에는 UI에 대한 마크업 데이터만 담고 싶어 기능을 별도의 함수로 분리하였습니다. 

이로 인해 기능 구현 중, 이벤트를 설정하는 과정에서 렌더링 시점이 맞지 않아 null로 설정되는 문제가 있었습니다. 

```js
/**
 * @description path에 따라 렌더해주는 함수. routes내 허용되는 값이 아닌 경우 에러페이지로 라우팅
 */
export const render = (path) => {
  const root = document.getElementById("root");
  const allowConditions = ["/", "/profile"];

  if (path === "/profile") {
    if (!checkLogin()) {
      navigateTo("/login");
      return;
    }
  }

  root.innerHTML = `
   <div class="bg-gray-100 min-h-screen flex justify-center">
      <div class="max-w-md w-full">
        ${allowConditions.includes(path) ? Header() : ""}
        ${routes[path] || ErrorPage()}
        ${allowConditions.includes(path) ? Footer() : ""}
      </div>
    </div>
  `;

  if (path === "/login") {
    login();
  }

```

렌더링 시점을 알맞게 조정하기 위해 path가 /login인 경우 로그인 함수를 불러올 수 있도록 구현했습니다. 

추가로, path경로가 `'/'`, `'/profile`인 경우에 헤더와 푸터 컴포넌트를 조건부 렌더링으로 보여지도록 설정했습니다. 

다만 이런 방식으로 구현하니 로그아웃을 구현하는 과정에서는 로그아웃 버튼을 받는 이벤트리스너도 렌더 함수에서 불러오게 되었습니다. 
추가로 선언해야하는 리스너가 늘어날 때마다 렌더함수에서 계속 선언해야하니 지금 선택한 방식이 맞는 지 잘 모르겠다는 생각이 듭니다. 
남은 기능을 구현한 후 리팩토링 시도해볼 예정입니다.